### PR TITLE
Add Feature 3: Count issues and events by GitHub username

### DIFF
--- a/feature3.py
+++ b/feature3.py
@@ -1,0 +1,43 @@
+from typing import List
+import matplotlib.pyplot as plt
+import numpy as np
+import pandas as pd
+
+from data_loader import DataLoader
+from model import Issue
+
+class Feature3:
+    """
+    Analyze GitHub issues and events to determine the number of issues and 
+    comments/events created by a specific user.
+    """
+
+    def __init__(self):
+        pass
+
+    def run(self):
+        # Prompt for username input
+        print("Feature 3 is running...")
+        username = input("Enter GitHub username: ").strip()
+        self.count_issues_and_events_by_user(username)
+
+    def count_issues_and_events_by_user(self, username: str):
+        issues: List[Issue] = DataLoader().get_issues()
+        
+        issue_count = 0
+        event_count = 0
+        
+        for issue in issues:
+            if issue.creator == username:
+                issue_count += 1
+            for event in issue.events:
+                if hasattr(event, 'actor') and event.actor == username:
+                    event_count += 1
+                elif hasattr(event, 'author') and event.author == username:
+                    event_count += 1
+        
+        print(f"{username} created {issue_count} issues and {event_count} comments/events.")
+
+
+if __name__ == '__main__':
+    Feature3().run()

--- a/run.py
+++ b/run.py
@@ -10,6 +10,8 @@ import argparse
 import config
 from example_analysis import ExampleAnalysis
 from feature1 import Feature1
+from feature3 import Feature3
+
 
 
 def parse_args():
@@ -53,6 +55,6 @@ elif args.feature == 1:
 elif args.feature == 2:
     pass # TODO call second analysis
 elif args.feature == 3:
-    pass # TODO call third analysis
+    Feature3().run()
 else:
     print('Need to specify which feature to run with --feature flag.')


### PR DESCRIPTION
(This is a copy of the original PR created by Jitesh)

Summary:
This feature prompts for a GitHub username as input and outputs the number of issues and comments/events created by that user.

Fixes & Changes:

Fixed incorrect attribute references (issue.author → issue.creator)

Feature tested and verified with multiple usernames

Output now correctly displays issue and event counts for the input user

Tested by: jitesh
All good to merge!